### PR TITLE
Fixed missing terminal newlines when calling '--help'

### DIFF
--- a/R/docopt.R
+++ b/R/docopt.R
@@ -86,7 +86,7 @@ extras <- function(help, version=NULL, options, doc){
   }
   if (help && any(names(opts) %in% c("-h","--help"))){
     help <- str_replace_all(doc, "^\\s*|\\s*$", "")
-    cat(help)
+    cat(help, '\n')
     if (interactive()) stop() else {
       quit(save="no")
     }


### PR DESCRIPTION
This pull request fixes a missing terminal newline after printing documentation via '--help'.

Before:
![screenshot from 2014-07-26 06 17 08](https://cloud.githubusercontent.com/assets/835618/3710446/5e39adb6-148c-11e4-8188-1d5b9f305df0.png)

I couldn't run your unit tests (I'm on an unstable version of roxygen), but travis-CI should test this pull request upon submission.

Edit: 
The unit tests still pass.
