### PR TITLE
Automatically load methods package when loading docopt.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,5 +10,6 @@ Description: docopt lets you define a command-line interface by just giving it
 License: MIT +file LICENSE
 URL: https://github.com/edwindj/docopt.R
 Imports:
-    stringr,
+    stringr
+Depends:
     methods


### PR DESCRIPTION
Hi Edwin,

Thanks for the great docopt package! Currently, one needs to load the methods package for each script manually. This change should cause methods to be loaded automatically with docopt. Feel free to ignore if this was intended, but I wanted to create a personal fork with this functionality.

Peter
