### PR TITLE
deal gracefully with given args

### DIFF
--- a/R/docopt.R
+++ b/R/docopt.R
@@ -37,13 +37,14 @@
 docopt <- function( doc, args=commandArgs(TRUE), name=NULL, help=TRUE, version=NULL
                   , strict=FALSE, strip_names=!strict, quoted_args=!strict
                   ){
-  # littler compatibility - map argv vector to args
-  if (exists("argv", where = .GlobalEnv, inherits = FALSE)) {
-    args = get("argv", envir = .GlobalEnv);
-  } 
   
   if (missing(args)) {
-    args <- quote_spaced(args)
+    # littler compatibility - map argv vector to args
+    if (exists("argv", where = .GlobalEnv, inherits = FALSE)) {
+      args = get("argv", envir = .GlobalEnv);
+    } else {
+			args <- quote_spaced(args)
+		}
   }
 
   args <- str_c(args, collapse=" ")


### PR DESCRIPTION
`docopt` does not deal correctly with the case of a given `args` argument when it is called by `r` ('little r'). This patch moves the detection of command-line args into the `missing` check block, so that code like

```
opt <- docopt(doc,args='--verbose --just-testing --etc')
```
works whether or not the code is ultimately called by `R` or `r`. 