### PR TITLE
remove no longer needed installation of r-cran-stringr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - ./run.sh bootstrap
 
 install:
-  - ./run.sh install_aptget r-cran-stringr r-cran-testthat
+  - ./run.sh install_aptget r-cran-testthat
 
 script:
   - ./run.sh run_tests


### PR DESCRIPTION
Quick and fairly trivial change -- we just don't need `stringr` anymore thanks to all your hard work.

Tried timing how much fast this makes the startup of `littler` and sadly it does not move the needle all that much.  But is *absolutely* the right longer-term choice.  Looking forward to seeing 0.6 on CRAN!