### PR TITLE
One-char fix commenting out a debugging aide

### DIFF
--- a/R/docopt.R
+++ b/R/docopt.R
@@ -46,7 +46,7 @@ docopt <- function( doc, args=commandArgs(TRUE), name=NULL, help=TRUE, version=N
 		}
   }
   
-  print(args)
+  #print(args)
   #browser()
   #args <- fix_quoted_options(args)
   #args <- str_c(args, collapse=" ")


### PR DESCRIPTION
Looks like a minor last-minute oversight.

I haven't fully digested the changed to quoted args, and while it is marginally breaking to (at least one) littler script I like it! Using `_` instead of having to quote with a hyphen (or minus) is better.  