### PR TITLE
Move very close to styler

### DIFF
--- a/tests/testthat/test-issues.R
+++ b/tests/testthat/test-issues.R
@@ -71,18 +71,18 @@ Options:
 })
 
 test_that("quotes inside options are preserved",{
-  "style files.
+  'style files.
 Usage:
-  style_files [--style_pkg=<style_guide_pkg>] [--arg=<arg1>] [--style_fun=<style_guide_fun>] <files>...
+  style_files [--style_pkg=<style_guide_pkg>] [--stlye_guide_transformer=<style_guide_transformers>] [--style_fun=<style_guide_fun>] <files>...
 
 Options:
   --style_pkg=<style_guide_pkg>  Package where the style guide is stored [default: styler].
-  --arg=<arg1>  Package where the style guide is stored [default: Arg1].
+  --stlye_guide_transformer=<style_guide_transformers> The `transformers` argument supplied to the styling API from the `style_pkg` namespace [default: tidyverse_style()].
   --style_fun=<style_guide_fun>  Deprecated in favor or `arg`. The styling function in style_pkg [default: tidyverse_style].
-" -> doc
+' -> doc
   
   # expected behavior
-  opt = docopt(doc, c("--style_pkg=styler", "--arg='tidyverse_style(scope = \"none\")'", "R/test.R"))
+  opt = docopt(doc, c("--style_pkg=styler", "--stlye_guide_transformer='tidyverse_style(scope = \"none\")'", "R/test.R"))
   expect_equal(opt$arg, "tidyverse_style(scope = \"none\")")
   expect_equal(opt$style_pkg, "styler")
 })

--- a/tests/testthat/test-issues.R
+++ b/tests/testthat/test-issues.R
@@ -73,14 +73,16 @@ Options:
 test_that("quotes inside options are preserved",{
   "style files.
 Usage:
-  style_files [--arg=<arg1>] <files>...
+  style_files [--style_pkg=<style_guide_pkg>] [--arg=<arg1>] <files>...
 
 Options:
+  --style_pkg=<style_guide_pkg>  Package where the style guide is stored [default: styler].
   --arg=<arg1>  Package where the style guide is stored [default: Arg1].
-
+  
 " -> doc
   
   # expected behavior
-  opt = docopt(doc, c("--arg='tidyverse_style(scope = \"none\")'", "R/test.R"))
+  opt = docopt(doc, c("--style_pkg=styler", "--arg='tidyverse_style(scope = \"none\")'", "R/test.R"))
   expect_equal(opt$arg, "tidyverse_style(scope = \"none\")")
+  expect_equal(opt$style_pkg, "styler")
 })

--- a/tests/testthat/test-issues.R
+++ b/tests/testthat/test-issues.R
@@ -73,12 +73,12 @@ Options:
 test_that("quotes inside options are preserved",{
   "style files.
 Usage:
-  style_files [--style_pkg=<style_guide_pkg>] [--arg=<arg1>] <files>...
+  style_files [--style_pkg=<style_guide_pkg>] [--arg=<arg1>] [--style_fun=<style_guide_fun>] <files>...
 
 Options:
   --style_pkg=<style_guide_pkg>  Package where the style guide is stored [default: styler].
   --arg=<arg1>  Package where the style guide is stored [default: Arg1].
-  
+  --style_fun=<style_guide_fun>  Deprecated in favor or `arg`. The styling function in style_pkg [default: tidyverse_style].
 " -> doc
   
   # expected behavior

--- a/tests/testthat/test-issues.R
+++ b/tests/testthat/test-issues.R
@@ -83,6 +83,6 @@ Options:
   
   # expected behavior
   opt = docopt(doc, c("--style_pkg=styler", "--stlye_guide_transformer='tidyverse_style(scope = \"none\")'", "R/test.R"))
-  expect_equal(opt$arg, "tidyverse_style(scope = \"none\")")
+  expect_equal(opt$stlye_guide_transformer, "tidyverse_style(scope = \"none\")")
   expect_equal(opt$style_pkg, "styler")
 })

--- a/tests/testthat/test-issues.R
+++ b/tests/testthat/test-issues.R
@@ -81,6 +81,6 @@ Options:
 " -> doc
   
   # expected behavior
-  opt = docopt(doc, c("--arg='tidyverse_style(scope= \"none\")'", "R/test.R"))
-  expect_equal(opt$arg, "tidyverse_style(scope= \"none\")")
+  opt = docopt(doc, c("--arg='tidyverse_style(scope = \"none\")'", "R/test.R"))
+  expect_equal(opt$arg, "tidyverse_style(scope = \"none\")")
 })


### PR DESCRIPTION
This PR is never intended to be merged. It demonstrates that the problems described in https://github.com/lorenzwalthert/precommit/issues/195 are not related to docopt, and probably occur earlier, i.e. in the way `commandArgs()` parses the input. We conclude this because this PR tests how docopt parses various different command line inputs into arguments and they all behave as expected. The full process fails, so probably docopt does not get the input we assume here.